### PR TITLE
Allow for prediction on nationwide data

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,9 @@ import os
 from datetime import datetime
 from fastapi import FastAPI, status
 
-from util import PredictionBody, fetch_data, get_region_data, ModelLibrary
+from util.exceptions import *
+from util import PredictionBody, ModelLibrary
+from util.data_retrieval import fetch_data, get_nation_data, get_region_data
 from dotenv import load_dotenv
 
 from ml import *
@@ -26,9 +28,16 @@ async def say_hello(name : str) :
     return {"message" : f"Hello {name}"}
 
 
-@app.get("/api/v1/covid/update/", status_code = status.HTTP_200_OK)
+@app.get("/api/v1/covid/update/", status_code = status.HTTP_204_NO_CONTENT)
 async def update() :
-    return {"test ok"}
+    # Update region data
+    overall_data = fetch_data(os.getenv("COV_NAT_DATA_URL"))
+    nation_data  = get_nation_data(overall_data)["P"]
+
+    # Create model
+    model = SarimaxModel("FRA")
+    model.fit(nation_data)
+    model.save()
 
 
 @app.get("/api/v1/covid/update/{region}", status_code = status.HTTP_204_NO_CONTENT)

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,3 +1,3 @@
-from .data_retrieval import fetch_data, get_region_data
+from .data_retrieval import fetch_data, get_region_data, get_nation_data
 from .request_bodies import PredictionBody
 from .model_library import ModelLibrary

--- a/util/data_retrieval.py
+++ b/util/data_retrieval.py
@@ -2,7 +2,7 @@ import io
 import pandas as pd
 import requests
 
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable
 
 
 def fetch_data(url : str) -> pd.DataFrame :
@@ -51,5 +51,20 @@ def get_region_data(data : pd.DataFrame,
     return reg_data
 
 
+def get_nation_data(data : pd.DataFrame) -> pd.DataFrame :
+    """
+    Returns the formatted data from a general dataset.
 
+    :param data: the general dataset
+    :return: the formatted dataset
+    """
 
+    to_remove = ["P_f", "P_h", "T_f", "T_h", "cl_age90", "pop", "jour", "fra"]
+
+    data.set_index(pd.to_datetime(data["jour"]), inplace = True)
+    data = data.drop(columns = to_remove)
+    data = data.groupby(level = "jour").sum()
+    data = data.sort_index()
+    data = data.asfreq("D")
+
+    return data


### PR DESCRIPTION
## Current Problem

The current API is suited to update models and predict from them when the data is regional. 
We would like to add nation wide support to the API

## Solution

Added a method to format the nationwide data, also using the existing data-fetching methods.
Added an endpoint for nationwide model updates.